### PR TITLE
Catch and log any exception when running a test

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -6375,7 +6375,7 @@ BEGIN
                     END IF;
                 END IF;
 
-            EXCEPTION WHEN raise_exception THEN
+            EXCEPTION WHEN OTHERS THEN
                 -- Something went wrong. Record that fact.
                 errstate := SQLSTATE;
                 errmsg := SQLERRM;


### PR DESCRIPTION
When an uncaught exception occurs within a test, unless the type is `raise_exception`, the exception is not caught by pgTAP and the test runner will terminate without returning results for any test. This change makes it catch all exceptions, log the failure details, and continue running tests.